### PR TITLE
Update extract-zip version to 1.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "es6-promise": "~4.0.3",
-    "extract-zip": "~1.5.0",
+    "extract-zip": "~1.6.5",
     "fs-extra": "~1.0.0",
     "hasha": "~2.2.0",
     "kew": "~0.7.0",


### PR DESCRIPTION
extract-zip 1.5.0 depends on [concat-stream 1.5.1 which contains a vulnerability](https://snyk.io/test/npm/concat-stream/1.5.1)


extract-zip 1.6.5 depends on an [updated version of concat-stream which fixes that vulnerability](https://snyk.io/test/npm/concat-stream/1.6.0).